### PR TITLE
fix: fork lastest block for pending proposals

### DIFF
--- a/presentation/markdown.ts
+++ b/presentation/markdown.ts
@@ -110,8 +110,8 @@ _Updated as of block [${blocks.current.number}](https://etherscan.io/block/${blo
   }](https://dashboard.tenderly.co/me/simulator/${sim.simulation.id})
 
 
-${subReports.length && `### Subreports`}
-${subReports.map((report) => `-[${report.name}](${report.link})\n`)}
+${subReports.length !== 0 && `### Subreports`}
+${subReports.map((report) => `- [${report.name}](${report.link})\n`)}
 
 <details>
   <summary>Proposal text</summary>

--- a/utils/simulations/proposal.ts
+++ b/utils/simulations/proposal.ts
@@ -80,12 +80,14 @@ export async function simulateProposal(proposalId: BigNumberish): Promise<Simula
     const duration = await executorContract.VOTING_DURATION()
     const quorum = await executorContract.MINIMUM_QUORUM()
 
-    const SNAPSHOT_BLOCK_NUMBER = proposal.startBlock.add(1).toNumber()
+    const CREATION_BLOCK_NUMBER = proposal.startBlock.add(1).toNumber()
     const VOTING_DURATION = duration.toNumber() + 1 // block number voting duration
     const VOTING_DELAY = delay.toNumber() + 1 // 1 sec margin in seconds
-    const EVM_BLOCK_NUMBER = SNAPSHOT_BLOCK_NUMBER + VOTING_DURATION
-    const EVM_EXECUTION_TIME = (await provider.getBlock(SNAPSHOT_BLOCK_NUMBER)).timestamp + VOTING_DURATION * 13
+    const EVM_BLOCK_NUMBER = CREATION_BLOCK_NUMBER + VOTING_DURATION
+    const EVM_EXECUTION_TIME = (await provider.getBlock(CREATION_BLOCK_NUMBER)).timestamp + VOTING_DURATION * 13
     const FORCED_EXECUTION_TIME = EVM_EXECUTION_TIME + VOTING_DELAY
+    // if a proposal is not yet finished instead of simulating at creation it makes sense to fork of the current block
+    const SNAPSHOT_BLOCK_NUMBER = EVM_BLOCK_NUMBER > latestBlock.number ? latestBlock.number : EVM_BLOCK_NUMBER - 1
 
     // Compute the approximate earliest possible execution time based on governance parameters. This
     // can only be approximate because voting period is defined in blocks, not as a timestamp. We


### PR DESCRIPTION
In the current simulation we take the block at proposal creation time which might be misleading as in the case of proposal `87` the simulation would always revert because the allowance from bal treasury was not given when the proposal was created. It was given though before the proposal ended. 

- also closes https://github.com/bgd-labs/seatbelt-for-ghosts/issues/11